### PR TITLE
Provide a way to skip the templating for torrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ available:
 Note that the defaults are the same as Tor's default if the
 configuration option is not set.
 
+If you set the SKIP_TEMPLATE variable to any value, the whole
+templating logic will be disabled and the configuration file
+/etc/tor/torrc will be used as is (either the default one provided by
+Tor or yours if you mount one in the container).
+
 You can use the `-m` option of Docker to mount a custom template in the
 image at `/etc/tor/torrc.template`. The templating engine
 (`envsubst`) will only replace specific environment variables in the

--- a/tor/tor-wrapper.sh
+++ b/tor/tor-wrapper.sh
@@ -22,6 +22,12 @@ if [ -f '/etc/torrc' ]; then
 		\echo 'DEBUG: Found existing /etc/torrc, overwritting /etc/tor/torrc.'
 	fi
 	\cp -f '/etc/torrc' '/etc/tor/torrc'
+	\echo 'WARN: Found configuration file at deprecated location /etc/torrc. Please use /etc/tor/torrc instead or it will stop working in future releases of this image.'
+elif [ -n "${SKIP_TEMPLATE+x}" ]; then
+	if [ "${DEBUG}" = true ]; then
+		\echo "DEBUG: Skipping templating since SKIP_TEMPLATE is set."
+	fi
+	\echo "Skipping templating."
 else
 	if [ -n "${SHELL_FORMAT+x}" ]; then
 		if [ "${DEBUG}" = true ]; then


### PR DESCRIPTION
Added the new SKIP_TEMPLATE environment variable: when set to any value, the templating of the torrc file will be skipped by the wrapper script and the /etc/tor/torrc file will be used verbatim (either the default one coming from the Tor project or one mounted by the user).