### PR TITLE
Consistancy check between provided torrc and SKIP_TEMPLATE

### DIFF
--- a/tor/tor-wrapper.sh
+++ b/tor/tor-wrapper.sh
@@ -23,12 +23,20 @@ if [ -f '/etc/torrc' ]; then
 	fi
 	\cp -f '/etc/torrc' '/etc/tor/torrc'
 	\echo 'WARN: Found configuration file at deprecated location /etc/torrc. Please use /etc/tor/torrc instead or it will stop working in future releases of this image.'
-elif [ -n "${SKIP_TEMPLATE+x}" ]; then
+fi
+if [ -n "${SKIP_TEMPLATE+x}" ]; then
 	if [ "${DEBUG}" = true ]; then
 		\echo "DEBUG: Skipping templating since SKIP_TEMPLATE is set."
 	fi
 	\echo "Skipping templating."
 else
+ if [ "${DEBUG}" = true ]; then
+		\echo "DEBUG: Using template since SKIP_TEMPLATE is not set."
+	fi
+ if [-f '/etc/tor/torrc' ]; then
+		>&2 \echo "ERROR: Cannot use both configuration template and provided torrc file. Either remove the torrc file or set SKIP_TEMPLATE to use provided torrc."
+  exit 1
+ fi
 	if [ -n "${SHELL_FORMAT+x}" ]; then
 		if [ "${DEBUG}" = true ]; then
 			\echo "DEBUG: Found custom Shell Format for envsubst: ${SHELL_FORMAT}"

--- a/tor/tor-wrapper.sh
+++ b/tor/tor-wrapper.sh
@@ -30,13 +30,13 @@ if [ -n "${SKIP_TEMPLATE+x}" ]; then
 	fi
 	\echo "Skipping templating."
 else
- if [ "${DEBUG}" = true ]; then
+	if [ "${DEBUG}" = true ]; then
 		\echo "DEBUG: Using template since SKIP_TEMPLATE is not set."
 	fi
- if [-f '/etc/tor/torrc' ]; then
+	if [ -f '/etc/tor/torrc' ]; then
 		>&2 \echo "ERROR: Cannot use both configuration template and provided torrc file. Either remove the torrc file or set SKIP_TEMPLATE to use provided torrc."
-  exit 1
- fi
+		exit 1
+	fi
 	if [ -n "${SHELL_FORMAT+x}" ]; then
 		if [ "${DEBUG}" = true ]; then
 			\echo "DEBUG: Found custom Shell Format for envsubst: ${SHELL_FORMAT}"


### PR DESCRIPTION
Providing a ready-made torrc file and setting SKIP_TEMPLATE at the same time doesn't make sense. It should be one or the other. Preventing startup in this scenario to make sure user notices.