### PR TITLE
Ignore existing `/etc/tor/torrc` on restart

### DIFF
--- a/tor/tor-wrapper.sh
+++ b/tor/tor-wrapper.sh
@@ -10,6 +10,10 @@ declare -l SKIP_TEMPLATE
 # skip template mode is off by default
 SKIP_TEMPLATE="${SKIP_TEMPLATE:-false}"
 
+declare -l CUSTOM_TORRC
+# custom torrc mode is off by default
+CUSTOM_TORRC="${CUSTOM_TORRC:-false}"
+
 declare -l SET_PERMISSIONS
 # set permissions mode is on by default
 SET_PERMISSIONS="${SET_PERMISSIONS:-true}"
@@ -40,7 +44,7 @@ else
 	if [ "${DEBUG}" = true ]; then
 		\echo "DEBUG: Using template since SKIP_TEMPLATE is not set."
 	fi
-	if [ -f '/etc/tor/torrc' ]; then
+	if [ "${CUSTOM_TORRC}" = true ] && [ -f '/etc/tor/torrc' ]; then
 		>&2 \echo "ERROR: Cannot use both configuration template and provided torrc file. Either remove the torrc file or set SKIP_TEMPLATE=true to use provided torrc."
 		exit 1
 	fi

--- a/tor/tor-wrapper.sh
+++ b/tor/tor-wrapper.sh
@@ -10,10 +10,6 @@ declare -l SKIP_TEMPLATE
 # skip template mode is off by default
 SKIP_TEMPLATE="${SKIP_TEMPLATE:-false}"
 
-declare -l CUSTOM_TORRC
-# custom torrc mode is off by default
-CUSTOM_TORRC="${CUSTOM_TORRC:-false}"
-
 declare -l SET_PERMISSIONS
 # set permissions mode is on by default
 SET_PERMISSIONS="${SET_PERMISSIONS:-true}"
@@ -44,9 +40,8 @@ else
 	if [ "${DEBUG}" = true ]; then
 		\echo "DEBUG: Using template since SKIP_TEMPLATE is not set."
 	fi
-	if [ "${CUSTOM_TORRC}" = true ] && [ -f '/etc/tor/torrc' ]; then
-		>&2 \echo "ERROR: Cannot use both configuration template and provided torrc file. Either remove the torrc file or set SKIP_TEMPLATE=true to use provided torrc."
-		exit 1
+	if [ -f '/etc/tor/torrc' ]; then
+		\echo "WARN: /etc/tor/torrc will be overwritten using template /etc/tor/torrc.template (set SKIP_TEMPLATE=true to disable this)."
 	fi
 	if [ -n "${SHELL_FORMAT+x}" ]; then
 		if [ "${DEBUG}" = true ]; then


### PR DESCRIPTION
This is more of a draft, but it works for me. If SKIP_TEMPLATE and CUSTOM_TORRC are set to false, then envsubst will always overwrite torrc when starting a container.
Fixes #201