### PR TITLE
Fix potential bug when `tor-wrapper.sh` is not executable

### DIFF
--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -18,7 +18,7 @@ RUN apk -U upgrade \
     && apk cache clean \
     && rm -rf /var/cache/apk/*
 
-RUN chmod o+rwx /etc/tor
+RUN chmod ugo+rwx /etc/tor
 
 COPY torrc.template tor-wrapper.sh /etc/tor/
 

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -20,9 +20,11 @@ RUN apk -U upgrade \
 
 RUN chmod o+rwx /etc/tor
 
-USER "tor"
-
 COPY torrc.template tor-wrapper.sh /etc/tor/
+
+RUN chmod ugo+rx /etc/tor/tor-wrapper.sh
+
+USER "tor"
 
 WORKDIR "/var/lib/tor"
 


### PR DESCRIPTION
If `tor-wrapper.sh` is not marked as executable on the host during the build, the built container will be broken. This small change fixes this bug.